### PR TITLE
Install mysqlclient if it was enabled in cookiecutter. fix #11.

### DIFF
--- a/{{cookiecutter.repo_name}}/requirements/base.txt
+++ b/{{cookiecutter.repo_name}}/requirements/base.txt
@@ -10,7 +10,12 @@ django-environ==0.4.3
 django-extensions==1.7.9
 django-model-utils==3.0.0
 Pillow==4.1.1
+{% if cookiecutter.use_postgresql == "y" or cookiecutter.use_postgis == "y" %}
 psycopg2==2.7.1
+{%- endif %}
+{%- if cookiecutter.use_mysql == 'y' %}
+mysqlclient==1.3.12
+{%- endif %}
 pytz==2017.2
 raven==6.1.0
 {%- if cookiecutter.use_redis == "y" %}


### PR DESCRIPTION
I am not sure if it is a good idea to NOT install psycopg if the user chose to not use postgresql neither postgis as it is the default database in the default settings.